### PR TITLE
Fixed laravel/framework 4.1.* requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Install the package through [Composer](http://getcomposer.org/). Edit your proje
 
 ```php
 "require": {
-	"laravel/framework": "4.0.*",
+	"laravel/framework": "4.1.*",
 	"gloudemans/shoppingcart": "dev-master"
 }
 ```


### PR DESCRIPTION
Updated from laravel/framework 4.0.\* to 4.1.*
