### PR TITLE
Support free products

### DIFF
--- a/src/Gloudemans/Shoppingcart/Cart.php
+++ b/src/Gloudemans/Shoppingcart/Cart.php
@@ -294,7 +294,7 @@ class Cart {
 	 */
 	protected function addRow($id, $name, $qty, $price, Array $options = array())
 	{
-		if(empty($id) || empty($name) || empty($qty) || empty($price))
+		if(empty($id) || empty($name) || empty($qty) || ! isset($price))
 		{
 			throw new Exceptions\ShoppingcartInvalidItemException;
 		}


### PR DESCRIPTION
I want to have free products in my cart to help bundle a purchase together for customers. empty() will return false for `int` 0, so this needs to use `! isset()` instead.
