### PR TITLE
Fix for issue #56: Destroy function doesn't return boolean

### DIFF
--- a/src/Gloudemans/Shoppingcart/Cart.php
+++ b/src/Gloudemans/Shoppingcart/Cart.php
@@ -389,11 +389,13 @@ class Cart {
 	 * Update the cart
 	 *
 	 * @param  Gloudemans\Shoppingcart\CartCollection  $cart  The new cart content
-	 * @return void
+	 * @return boolean
 	 */
 	protected function updateCart($cart)
 	{
-		return $this->session->put($this->getInstance(), $cart);
+		$this->session->put($this->getInstance(), $cart);
+
+		return $cart === $this->session->get($this->getInstance());
 	}
 
 	/**

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -423,6 +423,9 @@ class CartTest extends PHPUnit_Framework_TestCase {
 
 	public function testCartDestroyReturnsBoolean()
 	{
+		$this->events->shouldReceive('fire')->once()->with('cart.destroy');
+		$this->events->shouldReceive('fire')->once()->with('cart.destroyed');
+		
 		$this->assertTrue($this->cart->destroy());
 	}
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -421,5 +421,9 @@ class CartTest extends PHPUnit_Framework_TestCase {
 		$this->cart->associate('NoneExistingModel');
 	}
 
-}
+	public function testCartDestroyReturnsBoolean()
+	{
+		$this->assertTrue($this->cart->destroy());
+	}
 
+}


### PR DESCRIPTION
`Cart::destroy()` should now correctly return true or false.

[Issue #56](https://github.com/Crinsane/LaravelShoppingcart/issues/56)