### PR TITLE
#153 (Cannot add zero price) fixed

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -74,7 +74,7 @@ class CartItem
     {
         if(empty($id)) throw new \InvalidArgumentException('Please supply a valid identifier.');
         if(empty($name)) throw new \InvalidArgumentException('Please supply a valid name.');
-        if(empty($price) || ! is_numeric($price))
+        if(strlen($price) < 0 || ! is_numeric($price))
             throw new \InvalidArgumentException('Please supply a valid price.');
 
         $this->id = $id;


### PR DESCRIPTION
Reason: Zero (0/"0"), as an integer is empty. So, the empty() check before is_numeric() returns true when the value is 0 or "0".

Solution: I have replaced the empty() check with strlen($price) < 0.