### PR TITLE
Tax issue update

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -236,8 +236,8 @@ class Cart
     {
         $content = $this->getContent();
 
-        $total = $content->reduce(function ($subTotal, CartItem $cartItem) {
-            return $subTotal + ($cartItem->qty * $cartItem->price);
+        $total = $content->reduce(function ($total, CartItem $cartItem) {
+            return $total + ($cartItem->qty * $cartItem->priceTax);
         }, 0);
 
         return number_format($total, $decimals, $decimalPoint, $thousandSeperator);
@@ -272,9 +272,13 @@ class Cart
      */
     public function subtotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
     {
-        $subtotal = $this->total - $this->tax;
+        $content = $this->getContent();
 
-        return number_format($subtotal, $decimals, $decimalPoint, $thousandSeperator);
+        $subTotal = $content->reduce(function ($subTotal, CartItem $cartItem) {
+            return $subTotal + ($cartItem->qty * $cartItem->price);
+        }, 0);
+
+        return number_format($subTotal, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -303,8 +307,9 @@ class Cart
      */
     public function associate($rowId, $model)
     {
-        if(is_string($model) && ! class_exists($model))
+        if(is_string($model) && ! class_exists($model)) {
             throw new UnknownModelException("The supplied model {$model} does not exist.");
+        }
 
         $cartItem = $this->get($rowId);
 

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -168,7 +168,7 @@ class CartItem implements Arrayable
      */
     public function taxTotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
     {
-        return number_format(($this->tax * $this->qty), $decimals, $decimalPoint, $thousandSeperator);
+        return number_format($this->taxTotal, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -264,6 +264,10 @@ class CartItem implements Arrayable
 
         if($attribute === 'tax') {
             return $this->price * ($this->taxRate / 100);
+        }
+        
+        if($attribute === 'taxTotal') {
+            return $this->tax * $this->qty;
         }
 
         if($attribute === 'model') {

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -36,11 +36,12 @@ class CartItem implements Arrayable
     public $name;
 
     /**
-     * The price of the cart item.
+     * The price without TAX of the cart item.
      *
      * @var float
      */
     public $price;
+    
 
     /**
      * The options for this cart item.
@@ -73,21 +74,25 @@ class CartItem implements Arrayable
      */
     public function __construct($id, $name, $price, array $options = [])
     {
-        if(empty($id)) throw new \InvalidArgumentException('Please supply a valid identifier.');
-        if(empty($name)) throw new \InvalidArgumentException('Please supply a valid name.');
-        if(strlen($price) < 0 || ! is_numeric($price))
+        if(empty($id)) {
+            throw new \InvalidArgumentException('Please supply a valid identifier.');
+        }
+        if(empty($name)) {
+            throw new \InvalidArgumentException('Please supply a valid name.');
+        }
+        if(strlen($price) < 0 || ! is_numeric($price)) {
             throw new \InvalidArgumentException('Please supply a valid price.');
+        }
 
-        $this->id = $id;
-        $this->name = $name;
-        $this->price = $price;
-        $this->options = new CartItemOptions($options);
-
+        $this->id       = $id;
+        $this->name     = $name;
+        $this->price    = floatval($price);
+        $this->options  = new CartItemOptions($options);
         $this->rowId = $this->generateRowId($id, $options);
     }
 
     /**
-     * Returns the formatted price.
+     * Returns the formatted price without TAX.
      *
      * @param int    $decimals
      * @param string $decimalPoint
@@ -98,9 +103,23 @@ class CartItem implements Arrayable
     {
         return number_format($this->price, $decimals, $decimalPoint, $thousandSeperator);
     }
+    
+    /**
+     * Returns the formatted price with TAX.
+     *
+     * @param int    $decimals
+     * @param string $decimalPoint
+     * @param string $thousandSeperator
+     * @return string
+     */
+    public function priceTax($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    {
+        return number_format($this->priceTax, $decimals, $decimalPoint, $thousandSeperator);
+    }
 
     /**
      * Returns the formatted subtotal.
+     * Subtotal is price for whole CartItem without TAX
      *
      * @param int    $decimals
      * @param string $decimalPoint
@@ -110,6 +129,20 @@ class CartItem implements Arrayable
     public function subtotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
     {
         return number_format($this->subtotal, $decimals, $decimalPoint, $thousandSeperator);
+    }
+    
+    /**
+     * Returns the formatted total.
+     * Total is price for whole CartItem with TAX
+     *
+     * @param int    $decimals
+     * @param string $decimalPoint
+     * @param string $thousandSeperator
+     * @return string
+     */
+    public function total($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    {
+        return number_format($this->total, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -123,6 +156,19 @@ class CartItem implements Arrayable
     public function tax($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
     {
         return number_format($this->tax, $decimals, $decimalPoint, $thousandSeperator);
+    }
+    
+    /**
+     * Returns the formatted tax.
+     *
+     * @param int    $decimals
+     * @param string $decimalPoint
+     * @param string $thousandSeperator
+     * @return string
+     */
+    public function taxTotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    {
+        return number_format(($this->tax * $this->qty), $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -146,9 +192,10 @@ class CartItem implements Arrayable
      */
     public function updateFromBuyable(Buyable $item)
     {
-        $this->id = $item->getBuyableIdentifier();
-        $this->name = $item->getBuyableDescription();
-        $this->price = $item->getBuyablePrice();
+        $this->id       = $item->getBuyableIdentifier();
+        $this->name     = $item->getBuyableDescription();
+        $this->price    = $item->getBuyablePrice();
+        $this->priceTax = $this->price + $this->tax;
     }
 
     /**
@@ -159,11 +206,12 @@ class CartItem implements Arrayable
      */
     public function updateFromArray(array $attributes)
     {
-        $this->id = array_get($attributes, 'id', $this->id);
-        $this->qty = array_get($attributes, 'qty', $this->qty);
-        $this->name = array_get($attributes, 'name', $this->name);
-        $this->price = array_get($attributes, 'price', $this->price);
-        $this->options = new CartItemOptions(array_get($attributes, 'options', []));
+        $this->id       = array_get($attributes, 'id', $this->id);
+        $this->qty      = array_get($attributes, 'qty', $this->qty);
+        $this->name     = array_get($attributes, 'name', $this->name);
+        $this->price    = array_get($attributes, 'price', $this->price);
+        $this->priceTax = $this->price + $this->tax;
+        $this->options  = new CartItemOptions(array_get($attributes, 'options', []));
 
         $this->rowId = $this->generateRowId($this->id, $this->options->all());
     }
@@ -202,8 +250,16 @@ class CartItem implements Arrayable
             return $this->{$attribute};
         }
 
+        if($attribute === 'priceTax') {
+            return $this->price + $this->tax;
+        }
+        
         if($attribute === 'subtotal') {
             return $this->qty * $this->price;
+        }
+        
+        if($attribute === 'total') {
+            return $this->qty * ($this->priceTax);
         }
 
         if($attribute === 'tax') {

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -521,7 +521,7 @@ class CartTest extends Orchestra\Testbench\TestCase
         $cart->add($item2, 2);
 
         $this->assertItemsInCart(3, $cart);
-        $this->assertEquals(60.00, $cart->total);
+        $this->assertEquals(60.00, $cart->subtotal());
     }
 
     /** @test */
@@ -536,7 +536,7 @@ class CartTest extends Orchestra\Testbench\TestCase
         $cart->add($item2, 2);
 
         $this->assertItemsInCart(3, $cart);
-        $this->assertEquals('6.000,00', $cart->total(2, ',', '.'));
+        $this->assertEquals('6.000,00', $cart->subtotal(2, ',', '.'));
     }
 
     /** @test */
@@ -769,7 +769,7 @@ class CartTest extends Orchestra\Testbench\TestCase
         $cart->add($item, 1);
         $cart->add($item2, 2);
 
-        $this->assertEquals(39.50, $cart->subtotal);
+        $this->assertEquals(50.00, $cart->subtotal);
     }
 
     /** @test */
@@ -783,7 +783,7 @@ class CartTest extends Orchestra\Testbench\TestCase
         $cart->add($item, 1);
         $cart->add($item2, 2);
 
-        $this->assertEquals('3.950,00', $cart->subtotal(2, ',', '.'));
+        $this->assertEquals('5.000,00', $cart->subtotal(2, ',', '.'));
     }
 
     /** @test */
@@ -891,13 +891,16 @@ class CartTest extends Orchestra\Testbench\TestCase
 
         $cart->setTax('027c91341fd5cf4d2579b49c4b6a90da', 19);
 
-        $this->assertEquals(10.00, $cartItem->price);
-        $this->assertEquals(20.00, $cartItem->subtotal);
-        $this->assertEquals(1.90, $cartItem->tax);
+        $this->assertEquals(10.00, $cartItem->price(2));
+        $this->assertEquals(11.90, $cartItem->priceTax(2));
+        $this->assertEquals(20.00, $cartItem->subtotal(2));
+        $this->assertEquals(23.80, $cartItem->total(2));
+        $this->assertEquals(1.90, $cartItem->tax(2));
+        $this->assertEquals(3.80, $cartItem->taxTotal(2));
 
-        $this->assertEquals(16.20, $cart->subtotal);
-        $this->assertEquals(3.80, $cart->tax);
-        $this->assertEquals(20.00, $cart->total);
+        $this->assertEquals(20.00, $cart->subtotal(2));
+        $this->assertEquals(23.80, $cart->total(2));
+        $this->assertEquals(3.80, $cart->tax(2));
     }
 
     /**


### PR DESCRIPTION
I creaded couple of additional methods

When inserting product into cart, still use price without TAX (because of rounding when tax calculation from price with tax into price without tax, [see this issue for refference](https://github.com/Crinsane/LaravelShoppingcart/issues/164))

Now you can ask CartItem for unformatted properties
```
\CartItem::price //price without TAX
\CartItem::priceTax //price with TAX
\CartItem::subtotal //total without TAX
\CartItem::total //total with TAX
\CartItem::tax //TAX for 1 item
\CartItem::taxTotal //total TAX 
```

and formatting methods
```
\CartItem::price() //price without TAX
\CartItem::priceTax() //price with TAX
\CartItem::subtotal() //total without TAX
\CartItem::total() //total with TAX
\CartItem::tax() //TAX for 1 item
\CartItem::taxTotal() //total TAX 
```

As for \Cart
```
\Cart::subtotal() //total price without TAX
\Cart::total() //total price with TAX
\Cart::tax() //total TAX price
```

Please, let me know If you are OK with this fix.