### PR TITLE
Documentation updates + Tests fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ foreach($content as $row)
 <?php 
 
 /**
- * Let say we have a Product model that has a name and description but does not implements Buyable.
+ * Let say we have a Product model that has a name and description but does not implement Buyable.
  */
 
 $addition = Cart::add('293ad', 'Product 1', 1, 9.99, ['size' => 'large']);

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Cart::get($rowId);
 /**
  * Get the cart content
  *
- * @return CartCollection
+ * @return Illuminate\Support\Collection
  */
 
 Cart::content();
@@ -215,21 +215,23 @@ N.B. Keep in mind that the cart stays in the last set instance for as long as yo
 
 N.B.2 The default cart instance is called `main`, so when you're not using instances,`Cart::content();` is the same as `Cart::instance('main')->content()`.
 
-## Models
-A new feature is associating a model with the items in the cart. Let's say you have a `Product` model in your application. With the new `associate()` method, you can tell the cart that an item in the cart, is associated to the `Product` model. 
+## Models  
 
-That way you can access your model right from the `CartRowCollection`!
 
-Here is an example:
+In versions >=2.0, association works in a different way. Instead of calling the method `associate` to add an item to the cart as you would do, you have to either add a model that implements the `Buyable` contract or add the item and then associate it to a model.     
+
+If you choose the latter, you'll have to pass the fully qualified namespace of the model as the second parameter of the `associate` method, while the first one will be the additions' rowId. 
+
+`Buyable` implementation example:  
 
 ```php
 <?php 
 
 /**
- * Let say we have a Product model that has a name and description.
+ * Let say we have a Product model that has a name and description and also implements Buyable.
  */
 
-Cart::associate('Product')->add('293ad', 'Product 1', 1, 9.99, array('size' => 'large'));
+Cart::add(Product::find(1), 1);
 
 
 $content = Cart::content();
@@ -237,12 +239,36 @@ $content = Cart::content();
 
 foreach($content as $row)
 {
-	echo 'You have ' . $row->qty . ' items of ' . $row->product->name . ' with description: "' . $row->product->description . '" in your cart.';
+  echo 'You have ' . $row->qty . ' items of ' . $row->model->name . ' with description: "' . $row->model->description . '" in your cart.';
 }
-```
+```  
 
-The key to access the model is the same as the model name you associated (lowercase).
-The `associate()` method has a second optional parameter for specifying the model namespace.
+`Associate` implementation example:  
+
+```php
+<?php 
+
+/**
+ * Let say we have a Product model that has a name and description but does not implements Buyable.
+ */
+
+$addition = Cart::add('293ad', 'Product 1', 1, 9.99, ['size' => 'large']);
+
+Cart::associate($addition->rowId, \App\Product::class);
+
+
+$content = Cart::content();
+
+
+foreach($content as $row)
+{
+  echo 'You have ' . $row->qty . ' items of ' . $row->model->name . ' with description: "' . $row->model->description . '" in your cart.';
+}
+```  
+
+
+
+The key to access the model is `model`.
 
 ## Exceptions
 The Cart package will throw exceptions if something goes wrong. This way it's easier to debug your code using the Cart package or to handle the error based on the type of exceptions. The Cart packages can throw the following exceptions:

--- a/README.md
+++ b/README.md
@@ -175,14 +175,16 @@ Cart::subtotal($decimals, $decimalSeperator, $thousandSeperator);
  * @return Array|boolean
  */
 
- Cart::search(array('id' => 1, 'options' => array('size' => 'L'))); // Returns an array of rowid(s) of found item(s) or false on failure
+ Cart::search(['id' => 1, 'options' => ['size' => 'L']]); // Returns an array of rowId(s) of found item(s) or false on failure
 ```
 
 ## Collections
 
-As you might have seen, the `Cart::content()` and `Cart::get()` methods both return a Collection, a `CartCollection` and a `CartRowCollection`.
+As you might have seen, the `Cart::content()` and `Cart::get()` methods both return a Collection, therefore you can use all methods of [Laravel Collections](https://laravel.com/docs/master/collections).  
 
-These Collections extends the 'native' Laravel 4 Collection class, so all methods you know from this class can also be used on your shopping cart. With some addition to easily work with your carts content.
+Each item on the cart is an instance of `Gloudemans\Shoppingcart\CartItem` and contains an unique `rowId` (notice: those were called `rowid`, all lowercase, in previous versions) along it's various properties such as quantity, price and description.
+
+
 
 ## Instances
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Gloudemans\Shoppingcart\Cart;
+use Gloudemans\Shoppingcart\CartItemOptions;
 use Gloudemans\Shoppingcart\Contracts\Buyable;
-use Gloudemans\Shoppingcart\Contracts\Taxable;
 
 class CartTest extends Orchestra\Testbench\TestCase
 {
@@ -33,12 +33,12 @@ class CartTest extends Orchestra\Testbench\TestCase
 
         $app['config']->set('database.default', 'testing');
         $app['config']->set('database.connections.testing', [
-            'driver'   => 'sqlite',
+            'driver' => 'sqlite',
             'database' => ':memory:',
-            'prefix'   => '',
+            'prefix' => '',
         ]);
     }
-    
+
     /** @test */
     public function it_has_a_default_instance()
     {
@@ -63,7 +63,7 @@ class CartTest extends Orchestra\Testbench\TestCase
         $this->assertItemsInCart(1, $cart->instance(Cart::DEFAULT_INSTANCE));
         $this->assertItemsInCart(1, $cart->instance('wishlist'));
     }
-    
+
     /** @test */
     public function it_can_add_an_item()
     {
@@ -158,7 +158,7 @@ class CartTest extends Orchestra\Testbench\TestCase
 
         $cart->add([
             ['id' => 1, 'name' => 'Test item 1', 'qty' => 1, 'price' => 10.00],
-            ['id' => 2, 'name' => 'Test item 2', 'qty' => 1, 'price' => 10.00]
+            ['id' => 2, 'name' => 'Test item 2', 'qty' => 1, 'price' => 10.00],
         ]);
 
         $this->assertEquals(2, $cart->count());
@@ -480,6 +480,7 @@ class CartTest extends Orchestra\Testbench\TestCase
                 'price' => 10.00,
                 'tax' => 2.10,
                 'subtotal' => 10.0,
+                'options' => new CartItemOptions,
             ],
             '370d08585360f5c568b18d1f2e4ca1df' => [
                 'rowId' => '370d08585360f5c568b18d1f2e4ca1df',
@@ -489,7 +490,8 @@ class CartTest extends Orchestra\Testbench\TestCase
                 'price' => 10.00,
                 'tax' => 2.10,
                 'subtotal' => 10.0,
-            ]
+                'options' => new CartItemOptions,
+            ],
         ], $content->toArray());
     }
 
@@ -791,7 +793,7 @@ class CartTest extends Orchestra\Testbench\TestCase
     {
         $this->artisan('migrate', [
             '--database' => 'testing',
-            '--realpath' => realpath(__DIR__.'/../database/migrations'),
+            '--realpath' => realpath(__DIR__ . '/../database/migrations'),
         ]);
 
         $this->expectsEvents('cart.stored');
@@ -809,7 +811,7 @@ class CartTest extends Orchestra\Testbench\TestCase
         $this->seeInDatabase('shoppingcart', ['identifier' => $identifier, 'instance' => 'default', 'content' => $serialized]);
     }
 
-    /** 
+    /**
      * @test
      * @expectedException \Gloudemans\Shoppingcart\Exceptions\CartAlreadyStoredException
      * @expectedExceptionMessage A cart with identifier 123 was already stored.
@@ -818,7 +820,7 @@ class CartTest extends Orchestra\Testbench\TestCase
     {
         $this->artisan('migrate', [
             '--database' => 'testing',
-            '--realpath' => realpath(__DIR__.'/../database/migrations'),
+            '--realpath' => realpath(__DIR__ . '/../database/migrations'),
         ]);
 
         $this->expectsEvents('cart.stored');
@@ -839,7 +841,7 @@ class CartTest extends Orchestra\Testbench\TestCase
     {
         $this->artisan('migrate', [
             '--database' => 'testing',
-            '--realpath' => realpath(__DIR__.'/../database/migrations'),
+            '--realpath' => realpath(__DIR__ . '/../database/migrations'),
         ]);
 
         $this->expectsEvents('cart.restored');
@@ -868,7 +870,7 @@ class CartTest extends Orchestra\Testbench\TestCase
     {
         $this->artisan('migrate', [
             '--database' => 'testing',
-            '--realpath' => realpath(__DIR__.'/../database/migrations'),
+            '--realpath' => realpath(__DIR__ . '/../database/migrations'),
         ]);
 
         $cart = $this->getCart();
@@ -938,7 +940,9 @@ class CartTest extends Orchestra\Testbench\TestCase
     }
 }
 
-class ModelStub {
+class ModelStub
+{
     public $someValue = 'Some value';
-    public function find($id) { return $this; }
+    public function find($id)
+    {return $this;}
 }


### PR DESCRIPTION
Quick fix for `content`'s method docblock and `associate`/Model documentation.  

Update one:  
Minor test fix.  

Update two:  
Better `Collections` documentation.