### PR TITLE
Set default number format in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The method will automatically format the result, which you can tweak using the t
 Cart::total($decimals, $decimalSeperator, $thousandSeperator);
 ```
 
+You can set the default number format in the config file.
+
 **If you're not using the Facade, but use dependency injection in your (for instance) Controller, you can also simply get the total property `$cart->total`**
 
 ### Cart::tax()
@@ -187,6 +189,8 @@ The method will automatically format the result, which you can tweak using the t
 Cart::tax($decimals, $decimalSeperator, $thousandSeperator);
 ```
 
+You can set the default number format in the config file.
+
 **If you're not using the Facade, but use dependency injection in your (for instance) Controller, you can also simply get the tax property `$cart->tax`**
 
 ### Cart::subtotal()
@@ -202,6 +206,8 @@ The method will automatically format the result, which you can tweak using the t
 ```php
 Cart::subtotal($decimals, $decimalSeperator, $thousandSeperator);
 ```
+
+You can set the default number format in the config file.
 
 **If you're not using the Facade, but use dependency injection in your (for instance) Controller, you can also simply get the subtotal property `$cart->subtotal`**
 

--- a/config/cart.php
+++ b/config/cart.php
@@ -44,4 +44,24 @@ return [
 
     'destroy_on_logout' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Default number format
+    |--------------------------------------------------------------------------
+    |
+    | This defaults will be used for the formated numbers if you don't
+    | set them in the method call.
+    |
+    */
+
+    'format' => [
+
+        'decimals' => 2,
+
+        'decimal_point' => '.',
+
+        'thousand_seperator' => ','
+
+    ],
+
 ];

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -232,7 +232,7 @@ class Cart
      * @param string $thousandSeperator
      * @return string
      */
-    public function total($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function total($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
         $content = $this->getContent();
 
@@ -240,7 +240,7 @@ class Cart
             return $total + ($cartItem->qty * $cartItem->priceTax);
         }, 0);
 
-        return number_format($total, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($total, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -251,7 +251,7 @@ class Cart
      * @param string $thousandSeperator
      * @return float
      */
-    public function tax($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function tax($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
         $content = $this->getContent();
 
@@ -259,7 +259,7 @@ class Cart
             return $tax + ($cartItem->qty * $cartItem->tax);
         }, 0);
 
-        return number_format($tax, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($tax, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -270,7 +270,7 @@ class Cart
      * @param string $thousandSeperator
      * @return float
      */
-    public function subtotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function subtotal($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
         $content = $this->getContent();
 
@@ -278,7 +278,7 @@ class Cart
             return $subTotal + ($cartItem->qty * $cartItem->price);
         }, 0);
 
-        return number_format($subTotal, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($subTotal, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -407,15 +407,15 @@ class Cart
     public function __get($attribute)
     {
         if($attribute === 'total') {
-            return $this->total(2, '.', '');
+            return $this->total();
         }
 
         if($attribute === 'tax') {
-            return $this->tax(2, '.', '');
+            return $this->tax();
         }
 
         if($attribute === 'subtotal') {
-            return $this->subtotal(2, '.', '');
+            return $this->subtotal();
         }
 
         return null;
@@ -518,5 +518,23 @@ class Cart
         $connection = config('cart.database.connection');
 
         return is_null($connection) ? config('database.default') : $connection;
+    }
+
+    /**
+     * Get the Formated number
+     *
+     * @param $value
+     * @param $decimals
+     * @param $decimalPoint
+     * @param $thousandSeperator
+     * @return string
+     */
+    private function numberFormat($value, $decimals, $decimalPoint, $thousandSeperator)
+    {
+        $decimals = $decimals ?: config('cart.format.decimals') ?: 2;
+        $decimalPoint = $decimalPoint ?: config('cart.format.decimal_point') ?: '.';
+        $thousandSeperator = $thousandSeperator ?: config('cart.format.thousand_seperator') ?: ',';
+
+        return number_format($value, $decimals, $decimalPoint, $thousandSeperator);
     }
 }

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -99,9 +99,9 @@ class CartItem implements Arrayable
      * @param string $thousandSeperator
      * @return string
      */
-    public function price($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function price($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
-        return number_format($this->price, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($this->price, $decimals, $decimalPoint, $thousandSeperator);
     }
     
     /**
@@ -112,9 +112,9 @@ class CartItem implements Arrayable
      * @param string $thousandSeperator
      * @return string
      */
-    public function priceTax($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function priceTax($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
-        return number_format($this->priceTax, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($this->priceTax, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -126,9 +126,9 @@ class CartItem implements Arrayable
      * @param string $thousandSeperator
      * @return string
      */
-    public function subtotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function subtotal($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
-        return number_format($this->subtotal, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($this->subtotal, $decimals, $decimalPoint, $thousandSeperator);
     }
     
     /**
@@ -140,9 +140,9 @@ class CartItem implements Arrayable
      * @param string $thousandSeperator
      * @return string
      */
-    public function total($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function total($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
-        return number_format($this->total, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($this->total, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -153,9 +153,9 @@ class CartItem implements Arrayable
      * @param string $thousandSeperator
      * @return string
      */
-    public function tax($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function tax($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
-        return number_format($this->tax, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($this->tax, $decimals, $decimalPoint, $thousandSeperator);
     }
     
     /**
@@ -166,9 +166,9 @@ class CartItem implements Arrayable
      * @param string $thousandSeperator
      * @return string
      */
-    public function taxTotal($decimals = 2, $decimalPoint = '.', $thousandSeperator = ',')
+    public function taxTotal($decimals = null, $decimalPoint = null, $thousandSeperator = null)
     {
-        return number_format($this->taxTotal, $decimals, $decimalPoint, $thousandSeperator);
+        return $this->numberFormat($this->taxTotal, $decimals, $decimalPoint, $thousandSeperator);
     }
 
     /**
@@ -347,5 +347,23 @@ class CartItem implements Arrayable
             'tax'      => $this->tax,
             'subtotal' => $this->subtotal
         ];
+    }
+
+    /**
+     * Get the Formated number
+     *
+     * @param $value
+     * @param $decimals
+     * @param $decimalPoint
+     * @param $thousandSeperator
+     * @return string
+     */
+    private function numberFormat($value, $decimals, $decimalPoint, $thousandSeperator)
+    {
+        $decimals = $decimals ?: config('cart.format.decimals') ?: 2;
+        $decimalPoint = $decimalPoint ?: config('cart.format.decimal_point') ?: '.';
+        $thousandSeperator = $thousandSeperator ?: config('cart.format.thousand_seperator') ?: ',';
+
+        return number_format($value, $decimals, $decimalPoint, $thousandSeperator);
     }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -793,6 +793,48 @@ class CartTest extends Orchestra\Testbench\TestCase
     }
 
     /** @test */
+    public function it_can_return_cart_formated_numbers_by_config_values()
+    {
+        $this->setConfigFormat(2, ',', '.');
+
+        $cart = $this->getCart();
+
+        $item = $this->getBuyableMock(1, 'Some title', 1000.00);
+        $item2 = $this->getBuyableMock(2, 'Some title', 2000.00);
+
+        $cart->add($item, 1);
+        $cart->add($item2, 2);
+
+        $this->assertEquals('5.000,00', $cart->subtotal());
+        $this->assertEquals('1.050,00', $cart->tax());
+        $this->assertEquals('6.050,00', $cart->total());
+
+        $this->assertEquals('5.000,00', $cart->subtotal);
+        $this->assertEquals('1.050,00', $cart->tax);
+        $this->assertEquals('6.050,00', $cart->total);
+    }
+
+    /** @test */
+    public function it_can_return_cartItem_formated_numbers_by_config_values()
+    {
+        $this->setConfigFormat(2, ',', '.');
+
+        $cart = $this->getCart();
+        $item = $this->getBuyableMock(1, 'Some title', 2000.00);
+
+        $cart->add($item, 2);
+
+        $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
+
+        $this->assertEquals('2.000,00', $cartItem->price());
+        $this->assertEquals('2.420,00', $cartItem->priceTax());
+        $this->assertEquals('4.000,00', $cartItem->subtotal());
+        $this->assertEquals('4.840,00', $cartItem->total());
+        $this->assertEquals('420,00', $cartItem->tax());
+        $this->assertEquals('840,00', $cartItem->taxTotal());
+    }
+
+    /** @test */
     public function it_can_store_the_cart_in_a_database()
     {
         $this->artisan('migrate', [
@@ -957,6 +999,20 @@ class CartTest extends Orchestra\Testbench\TestCase
         $item->shouldReceive('getBuyablePrice')->andReturn($price);
 
         return $item;
+    }
+
+    /**
+     * Set the config number format
+     * 
+     * @param $decimals
+     * @param $decimalPoint
+     * @param $thousandSeperator
+     */
+    private function setConfigFormat($decimals, $decimalPoint, $thousandSeperator)
+    {
+        $this->app['config']->set('cart.format.decimals', $decimals);
+        $this->app['config']->set('cart.format.decimal_point', $decimalPoint);
+        $this->app['config']->set('cart.format.thousand_seperator', $thousandSeperator);
     }
 }
 


### PR DESCRIPTION
Hi there,

Thanks for writing this package.

I added the option to put the number format parameters in the config file. 
```
'format' => [
        'decimals' => 2,
        'decimal_point' => '.',
        'thousand_seperator' => ','
    ],
```

All the original functionality of the package remain the same, but now if I want all my decimal points to be ',', I will change the config file instead of passing the same parameter every time I need the formated number. 

If someone remove the config option, the package will still default to the original format 2, '.', ','

Please, let me know what you think.