### PR TITLE
Bugfix adding cartitem different models

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -450,7 +450,6 @@ class Cart
         if ($id instanceof Buyable) {
             $cartItem = CartItem::fromBuyable($id, $qty ?: []);
             $cartItem->setQuantity($name ?: 1);
-            $cartItem->associate($id);
         } elseif (is_array($id)) {
             $cartItem = CartItem::fromArray($id);
             $cartItem->setQuantity($id['qty']);

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -72,7 +72,7 @@ class CartItem implements Arrayable
      * @param float      $price
      * @param array      $options
      */
-    public function __construct($id, $name, $price, array $options = [])
+    public function __construct($id, $name, $price, array $options = [], $model = null)
     {
         if(empty($id)) {
             throw new \InvalidArgumentException('Please supply a valid identifier.');
@@ -88,7 +88,13 @@ class CartItem implements Arrayable
         $this->name     = $name;
         $this->price    = floatval($price);
         $this->options  = new CartItemOptions($options);
-        $this->rowId = $this->generateRowId($id, $options);
+
+        // First associate with model if possible
+        if (!is_null($model))
+            $this->associate($model);
+
+        // Then generate rowId
+        $this->rowId            = $this->generateRowId($id, $options);
     }
 
     /**
@@ -286,7 +292,7 @@ class CartItem implements Arrayable
      */
     public static function fromBuyable(Buyable $item, array $options = [])
     {
-        return new self($item->getBuyableIdentifier($options), $item->getBuyableDescription($options), $item->getBuyablePrice($options), $options);
+        return new self($item->getBuyableIdentifier($options), $item->getBuyableDescription($options), $item->getBuyablePrice($options), $options, $item);
     }
 
     /**
@@ -327,7 +333,7 @@ class CartItem implements Arrayable
     {
         ksort($options);
 
-        return md5($id . serialize($options));
+        return md5($id . serialize($options) . $this->associatedModel);
     }
 
     /**


### PR DESCRIPTION
In this commit we include the associatedModel in the generation process of the rowId. 
By doing so we are able to add multiple items to the cart that have a same id (e.g. id = 1) but have a different associated Model. (e.g. Product and Product Option) They will then appear as different items on the cart. (and not as the same item, but with wrongly updated data).
In addition, it is now possible to set the associated model on creation of a cart item, by passing on a parameter to the construct method.
