### PR TITLE
Fixed priceTax attribute not updating.

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -238,6 +238,8 @@ class CartItem implements Arrayable
     public function setTaxRate($taxRate)
     {
         $this->taxRate = $taxRate;
+
+        $this->priceTax = $this->price + $this->tax;
         
         return $this;
     }


### PR DESCRIPTION
When calling Cart::setTax() or setTaxRate on the CartItem object, the
new priceTax is not updated to reflect the new tax rate. The total()
method then does not have the correct total.