### PR TITLE
return row on update

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -116,7 +116,7 @@ class Cart
      *
      * @param string $rowId
      * @param mixed  $qty
-     * @return void
+     * @return \Gloudemans\Shoppingcart\CartItem
      */
     public function update($rowId, $qty)
     {
@@ -151,6 +151,8 @@ class Cart
         $this->events->fire('cart.updated', $cartItem);
 
         $this->session->put($this->instance, $content);
+
+        return $cartItem;
     }
 
     /**


### PR DESCRIPTION
When updating a cartItem it should be returned since updating it might
change it’s ID