### PR TITLE
Associate the cartitem with a model directly

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -305,11 +305,13 @@ class Cart
      */
     public function associate($rowId, $model)
     {
-        if(is_string($model) && ! class_exists($model)) {
-            throw new UnknownModelException("The supplied model {$model} does not exist.");
-        }
-
         $cartItem = $this->get($rowId);
+        if (is_string($model)) {
+            if (! class_exists($model)) {
+                throw new UnknownModelException("The supplied model {$model} does not exist.");
+            }
+            $model = $model::find($cartItem->id);
+        }
 
         $cartItem->associate($model);
 
@@ -349,7 +351,6 @@ class Cart
     public function store($identifier)
     {
         $content = $this->getContent();
-
         if ($this->storedCartWithIdentifierExists($identifier)) {
             throw new CartAlreadyStoredException("A cart with identifier {$identifier} was already stored.");
         }

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -224,8 +224,14 @@ class CartItem implements Arrayable
      */
     public function associate($model)
     {
-        $this->associatedModel = is_string($model) ? $model : get_class($model);
-        
+        if ( is_string($model) ) {
+            if (! class_exists($model)) {
+                throw new UnknownModelException("The supplied model {$model} does not exist.");
+            }
+            $model = $model::find($this->id);
+        }
+        $this->associatedModel = $model;
+
         return $this;
     }
 
@@ -275,7 +281,7 @@ class CartItem implements Arrayable
         }
 
         if($attribute === 'model') {
-            return with(new $this->associatedModel)->find($this->id);
+            return $this->associatedModel;
         }
 
         return null;

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -613,8 +613,8 @@ class CartTest extends Orchestra\Testbench\TestCase
         $cart->add($item);
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
-
-        $this->assertContains('Gloudemans_Shoppingcart_Contracts_Buyable', PHPUnit_Framework_Assert::readAttribute($cartItem, 'associatedModel'));
+        $this->assertEquals($cartItem->associatedModel, $item);
+        // $this->assertContains('Gloudemans_Shoppingcart_Contracts_Buyable', PHPUnit_Framework_Assert::readAttribute($cartItem, 'associatedModel'));
     }
 
     /** @test */
@@ -630,7 +630,8 @@ class CartTest extends Orchestra\Testbench\TestCase
 
         $cartItem = $cart->get('027c91341fd5cf4d2579b49c4b6a90da');
 
-        $this->assertEquals(get_class($model), PHPUnit_Framework_Assert::readAttribute($cartItem, 'associatedModel'));
+        $this->assertEquals($cartItem->associatedModel, $model);
+        // $this->assertEquals(get_class($model), PHPUnit_Framework_Assert::readAttribute($cartItem, 'associatedModel'));
     }
 
     /**


### PR DESCRIPTION
Hello,

I was doing some work with the cart this morning, and noticed that every time I accessed CartItem::Model it would perform a new database query to actually fetch the model.  

I wonder if it would be possible to associate the model directly instead?  Or somehow cache it...  This PR is a quick stab at it, but it currently fails tests the serialization to database tests (I'm assuming serializing the nested object is causing issues, I haven't had time to dig deeply into it yet--and won't for a day or so, but wanted to get thoughts on this).

My other thought/wonder is if this will turn into too much information to store in the session?  Is there a better way for me to approach this?

Thanks,