### PR TITLE
Removed generating new rowId on Update.

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -212,8 +212,6 @@ class CartItem implements Arrayable
         $this->price    = array_get($attributes, 'price', $this->price);
         $this->priceTax = $this->price + $this->tax;
         $this->options  = new CartItemOptions(array_get($attributes, 'options', $this->options));
-
-        $this->rowId = $this->generateRowId($this->id, $this->options->all());
     }
 
     /**


### PR DESCRIPTION
If the rowId is generated again on update, the item cannot be retrieved from the Cart instance anymore .