### PR TITLE
Allow for adding cart items with zero quantity

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -141,12 +141,7 @@ class Cart
             }
         }
 
-        if ($cartItem->qty <= 0) {
-            $this->remove($cartItem->rowId);
-            return;
-        } else {
-            $content->put($cartItem->rowId, $cartItem);
-        }
+        $content->put($cartItem->rowId, $cartItem);
 
         $this->events->fire('cart.updated', $cartItem);
 
@@ -451,7 +446,7 @@ class Cart
     {
         if ($id instanceof Buyable) {
             $cartItem = CartItem::fromBuyable($id, $qty ?: []);
-            $cartItem->setQuantity($name ?: 1);
+            $cartItem->setQuantity($name ?: 0);
             $cartItem->associate($id);
         } elseif (is_array($id)) {
             $cartItem = CartItem::fromArray($id);

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -178,8 +178,8 @@ class CartItem implements Arrayable
      */
     public function setQuantity($qty)
     {
-        if(empty($qty) || ! is_numeric($qty))
-            throw new \InvalidArgumentException('Please supply a valid quantity.');
+        if(! is_numeric($qty))
+            throw new \InvalidArgumentException('Please supply a numeric value for the quantity.');
 
         $this->qty = $qty;
     }


### PR DESCRIPTION
Allow for adding cart items with zero quantity. This will enable some business cases that are governed by some specific business rules.

I have several use-cases where the quantity is only added later via an update for specific usability/process, business and security rules. E.g. tickets for events are added to the cart but the people (quantity) is only done during the checkout process and based on specific business rules.

With the older version it was possible to update the cart item's quantity to 0 and the cart still returned the item when called with the content() method and pricing, etc. correctly which was awesome! :) Please consider to allow this again as the current lock down of quantity must be 1 is problematic.

Users can use 

Cart::content()->count() to get the distinct number of items in the cart.

Thanks!