### PR TITLE
Update to store created/modified times

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -358,6 +358,8 @@ class Cart
             'identifier' => $identifier,
             'instance' => $this->currentInstance(),
             'content' => serialize($content)
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s')
         ]);
 
         $this->events->fire('cart.stored');


### PR DESCRIPTION
The store method omits the timestamps that are present in the migration file.