### PR TITLE
Revised fix for missing timestamps

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -357,7 +357,9 @@ class Cart
         $this->getConnection()->table($this->getTableName())->insert([
             'identifier' => $identifier,
             'instance' => $this->currentInstance(),
-            'content' => serialize($content)
+            'content' => serialize($content),
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s')
         ]);
 
         $this->events->fire('cart.stored');


### PR DESCRIPTION
The migration file for shoppingcart sets up timestamps for created and updated but these are saved when the cared is stored. This should fix that.