### PR TITLE
Update CartItem.php

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -274,7 +274,7 @@ class CartItem implements Arrayable, Jsonable
             return $this->tax * $this->qty;
         }
 
-        if($attribute === 'model') {
+        if($attribute === 'model' && isset($this->associatedModel)) {
             return with(new $this->associatedModel)->find($this->id);
         }
 


### PR DESCRIPTION
Fix fatal error caused by instantiating a null associatedModel.

I ran into this bug when I had a cart with a mix of CartItems that had associated models and CartItems that didn't.

For example consider the following code:
```
        $cartItemModel = Product::find(1);
        Cart::add($cartItemModel);
        Cart::add('servicefee', 'Some Fee', 1, 9.99);

        foreach (Cart::content() as $item) {
            echo $item->model;
        }
```

Produces the error:
(1/1) FatalErrorException
Class name must be a valid object or a string
in CartItem.php (line 278)

![screen shot 2017-08-22 at 11 04 39 am](https://user-images.githubusercontent.com/1827586/29575578-8890a79a-872a-11e7-8d59-1ef793c8366a.png)
