### PR TITLE
MongoDB Driver issue

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -378,11 +378,11 @@ class Cart
         $stored = $this->getConnection()->table($this->getTableName())
             ->where('identifier', $identifier)->first();
 
-        $storedContent = unserialize($stored->content);
+        $storedContent = unserialize(data_get($stored, 'content'));
 
         $currentInstance = $this->currentInstance();
 
-        $this->instance($stored->instance);
+        $this->instance(data_get($stored, 'instance'));
 
         $content = $this->getContent();
 


### PR DESCRIPTION
There is an issue when calling the MongoDB connection outside of models, which returns the data in an array-like format. 

```
array:4 [▼
  "_id" => ObjectId {#1320 ▶}
  "identifier" => "5ace56e3f04705104e791d82"
  "instance" => "default"
  "content" => "O:29:"Illuminate\Support\Collection":1:{s:8:"\x00*\x00items";a:1:{s:32:"66afafbaabfae38bb9f68e8be9e509a8";O:32:"Gloudemans\Shoppingcart\CartItem":8:{s:5:"rowId" ▶"
]
```

This issue is not present on default MySQL driver. 

By utilizing Laravel's [data_get](https://laravel.com/docs/5.6/helpers#method-data-get) helper, we can easily add support for MongoDB and perhaps any other NoSQL database.