### PR TITLE
Add support for laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-        "illuminate/session": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-        "illuminate/events": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*|| 5.6.* || 5.7.*",
+        "illuminate/session": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*|| 5.6.* || 5.7.*",
+        "illuminate/events": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*|| 5.6.* || 5.7.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0|~6.0|~7.0",
+        "phpunit/phpunit": "~5.0 || ~6.0 || ~7.0",
         "mockery/mockery": "~0.9.0",
         "orchestra/testbench": "~3.1"
     },


### PR DESCRIPTION
This PR adds support for Laravel 5.7. Also the single pipe got replaced with double pipes. This is the recommend or operator for composer. See also https://github.com/composer/composer/issues/6755