### PR TITLE
Add deleteRecord Parameter

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -369,7 +369,7 @@ class Cart
      * @param mixed $identifier
      * @return void
      */
-    public function restore($identifier)
+    public function restore($identifier, $deleteRecord=true)
     {
         if( ! $this->storedCartWithIdentifierExists($identifier)) {
             return;
@@ -395,9 +395,10 @@ class Cart
         $this->session->put($this->instance, $content);
 
         $this->instance($currentInstance);
-
-        $this->getConnection()->table($this->getTableName())
+        if($deleteRecord){
+            $this->getConnection()->table($this->getTableName())
             ->where('identifier', $identifier)->delete();
+        }
     }
 
     /**


### PR DESCRIPTION
As i knew that the default behavior of the restore method is deleting the database record after it finished restoring, but this is not a helpful in case we're building the application to give a mobile app api so i added the ability to disable this action as it'll restore the cart but not deleting it